### PR TITLE
add: product badge type and color to PDP and PLP views

### DIFF
--- a/assets/product-badge.css
+++ b/assets/product-badge.css
@@ -1,0 +1,37 @@
+.product__info-badge {
+    --product-badge-height: 2.25em;
+
+    width: fit-content;
+    max-width: 15em;
+    height: var(--product-badge-height);
+    border-radius: calc(var(--product-badge-height)/2);
+    padding: 0 0.5em;
+    display: flex;
+    justify-content: center;
+}
+
+.product__info-badge-text {
+    margin: auto;
+    font-size: larger;
+    color: white;
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}
+
+.card__media-product-badge {
+    --product-badge-height: 1.75em;
+
+    width: fit-content;
+    max-width: 15em;
+    height: var(--product-badge-height);
+    border-radius: calc(var(--product-badge-height)/2);
+    padding: 0 0.5em;
+    position: fixed;
+    top: 10%;
+    right: 10%;
+}
+
+.card__media-badge-text {
+    margin: auto;
+    color: white;
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -9,6 +9,7 @@
   {{ 'component-slider.css' | asset_url | stylesheet_tag }}
   {{ 'component-rating.css' | asset_url | stylesheet_tag }}
   {{ 'component-deferred-media.css' | asset_url | stylesheet_tag }}
+  {{ 'product-badge.css' |  asset_url |  stylesheet_tag }}
   {%- if product.quantity_price_breaks_configured? -%}
     {{ 'component-volume-pricing.css' | asset_url | stylesheet_tag }}
   {%- endif -%}
@@ -74,6 +75,15 @@
         class="product__info-container{% if section.settings.enable_sticky_info %} product__column-sticky{% endif %}"
       >
         {%- assign product_form_id = 'product-form-' | append: section.id -%}
+
+        {%- unless product.metafields.custom.badge_type.value contains 'none' or product.metafields.custom.badge_type.value == blank -%}
+          <div 
+            style="background-color: {{ product.metafields.custom.badge_color | default: '#87CEEB'}}"
+            class="product__info-badge"
+          >
+            <p class="product__info-badge-text">{{ product.metafields.custom.badge_type.value}}</p>
+          </div>
+        {%- endunless -%}
 
         {%- for block in section.blocks -%}
           {%- case block.type -%}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -22,6 +22,7 @@
 
 {{ 'component-rating.css' | asset_url | stylesheet_tag }}
 {{ 'component-volume-pricing.css' | asset_url | stylesheet_tag }}
+{{ 'product-badge.css' |  asset_url |  stylesheet_tag }}
 
 {%- if card_product and card_product != empty -%}
   {%- liquid
@@ -99,6 +100,14 @@
                 >
               {%- endif -%}
             </div>
+            {%- unless card_product.metafields.custom.badge_type.value contains 'none' or card_product.metafields.custom.badge_type.value == blank -%}
+              <div 
+                style="z-index: 10;background-color: {{ card_product.metafields.custom.badge_color | default: '#87CEEB'}}"
+                class="card__media-product-badge"
+              >
+                <p class="card__media-badge-text">{{ card_product.metafields.custom.badge_type.value}}</p>
+              </div>
+            {%- endunless -%}
           </div>
         {%- endif -%}
         <div class="card__content">


### PR DESCRIPTION
### PR Summary: 



### Testing steps/scenarios

- [x] Try to add badge type to product (should pass)
- [x] Try to add valid badge color to product (should pass)
- [x] try only `#` in badge color (should fail)
- [x] try only 3 chars a-fA-F0-9 without `#` in front (should fail)
- [x] try only 6 chars a-fA-F0-9 without `#` in front (should fail)
- [x] try only 3 chars a-fA-F0-9 with `#` in front (should fail)
- [x] try only 6 chars a-fA-F0-9  with `#` in front (should fail)
---
- [x] check badge in PLP
  - [x] check valid badge type without color (badge with default color should appear)
    - [x] **pre-order** 
    - [x] **sale** 
    - [x] **featured**
  - [x] check `none` badge type without color (badge should not appear)
  - [x] check undefined badge type without color (badge should not appear)
  - [x] check valid badge + color
---
- [x] check badge in PDP
  - [x] check valid badge type without color (badge with default color should appear)
    - [x] **pre-order** 
    - [x] **sale** 
    - [x] **featured**
  - [x] check `none` badge type without color (badge should not appear)
  - [x] check undefined badge type without color (badge should not appear)
  - [x] check valid badge + color
---
- [x] Perform this same tests on mobile (Samsung, android 13, 1080 x 2400, 411 ppi, 6,3")

### Demo links

- [Store](https://quickstart-0e0e327e.myshopify.com/)

### Checklist
- [x] add `badge type` metafield to `Product` -> selectable **pre-order** **sale** **featured**
- [x] add `badge color` metafield to `Product` (string that takes 4-7 chars `#` + 3 or 6 `0-9a-fA-F` chars)
- [x] add possibility to remove badge
- [x] add badge to PLP
- [x] add badge to PDP

